### PR TITLE
feat: adds `pgproto.UUID` to the type_encoders

### DIFF
--- a/litestar_asyncpg/plugin.py
+++ b/litestar_asyncpg/plugin.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from asyncpg.pgproto import pgproto
 from litestar.di import Provide
 from litestar.plugins import InitPluginProtocol
 
@@ -50,6 +51,7 @@ class AsyncpgPlugin(InitPluginProtocol, SlotsBase):
                 "db_connection": Provide(self._config.provide_connection),
             },
         )
+        app_config.type_encoders = {pgproto.UUID: str, **(app_config.type_encoders or {})}
         app_config.before_send.append(self._config.before_send_handler)
         app_config.lifespan.append(self._config.lifespan)
         app_config.signature_namespace.update(self._config.signature_namespace)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ license = {text = "MIT"}
 name = "litestar-asyncpg"
 readme = "README.md"
 requires-python = ">=3.8"
-version = "0.1.1"
+version = "0.1.2"
 
 [project.urls]
 Changelog = "https://cofin.github.io/litesatr-asyncpg/latest/changelog"


### PR DESCRIPTION
This PR adds the asyncpg UUID to the `type_encoders` of the application.